### PR TITLE
WIP: Add endpoint to create RMAP for a node

### DIFF
--- a/tests/base.py
+++ b/tests/base.py
@@ -132,7 +132,7 @@ class DbTestCase(unittest.TestCase):
         settings.ENABLE_EMAIL_SUBSCRIPTIONS = False
 
         cls._original_bcrypt_log_rounds = settings.BCRYPT_LOG_ROUNDS
-        settings.BCRYPT_LOG_ROUNDS = 1
+        settings.BCRYPT_LOG_ROUNDS = 4
 
         teardown_database(database=database_proxy._get_current_object())
         # TODO: With `database` as a `LocalProxy`, we should be able to simply

--- a/tests/test_rmap.py
+++ b/tests/test_rmap.py
@@ -1,0 +1,50 @@
+# -*- coding: utf-8 -*-
+import mock
+from nose.tools import *  # flake8: noqa
+
+from framework.auth.core import Auth
+from tests.base import OsfTestCase
+
+from tests.factories import AuthUserFactory, ProjectFactory
+
+
+class TestRmapViews(OsfTestCase):
+
+    def setUp(self):
+        super(TestRmapViews, self).setUp()
+        self.user = AuthUserFactory()
+        self.project = ProjectFactory(creator=self.user, is_public=True)
+        self.url = self.project.api_url_for('node_rmap_post')
+
+    @mock.patch('website.project.views.rmap._create_rmap_for_node')
+    def test_rmap_post_valid(self, mock_create_rmap):
+        mock_create_rmap.return_value = 'abc123'
+        res = self.app.post_json(self.url, {}, auth=self.user.auth)
+        assert_equal(res.status_code, 201)
+        self.project.reload()
+        # Project now has a rmap identifier
+        rmap_id = self.project.get_identifier('rmap')
+        assert_true(bool(rmap_id))
+        assert_equal(rmap_id.value, 'abc123')
+
+        # Request was made
+        mock_create_rmap.assert_called()
+        mock_create_rmap.assert_called_with(self.project)
+
+    def test_rmap_post_non_contributor_should_error(self):
+        noncontrib = AuthUserFactory()
+        res = self.app.post_json(self.url, {}, auth=noncontrib.auth, expect_errors=True)
+        assert_equal(res.status_code, 403)
+
+    def test_rmap_post_non_admin_contributor_should_error(self):
+        non_admin = AuthUserFactory()
+        self.project.add_contributor(non_admin, permissions=['read', 'write'], auth=Auth(self.user))
+        self.project.save()
+        res = self.app.post_json(self.url, {}, auth=non_admin.auth, expect_errors=True)
+        assert_equal(res.status_code, 403)
+
+    def test_rmap_post_non_public_project_should_error(self):
+        private_project = ProjectFactory(creator=self.user, is_public=False)
+        url = private_project.api_url_for('node_rmap_post')
+        res = self.app.post_json(url, {}, auth=self.user.auth, expect_errors=True)
+        assert_equal(res.status_code, 400)

--- a/website/project/views/__init__.py
+++ b/website/project/views/__init__.py
@@ -1,1 +1,1 @@
-from . import contributor, node, register, tag, file, comment, drafts  # noqa
+from . import contributor, node, register, tag, file, comment, drafts, rmap  # noqa

--- a/website/project/views/rmap.py
+++ b/website/project/views/rmap.py
@@ -1,0 +1,25 @@
+from framework.exceptions import HTTPError
+from website.project.decorators import (
+    must_be_valid_project,
+    must_have_permission,
+)
+from website.util.permissions import ADMIN
+
+
+def _create_rmap_for_node(node):
+    # TODO: Make request to RMAP service
+    return '<rmapid would be returned>'
+
+
+@must_be_valid_project
+@must_have_permission(ADMIN)
+def node_rmap_post(node, auth, *args, **kwargs):
+    if not node.is_public:
+        raise HTTPError(400, data=dict(message_long='RMaps can only be created '
+                                       'for public projects. Make your project public '
+                                       'and retry your request.'))
+    rmap_id = _create_rmap_for_node(node)
+    node.set_identifier_value('rmap', rmap_id)
+    return {
+        'rmap_id': rmap_id
+    }, 201

--- a/website/routes.py
+++ b/website/routes.py
@@ -1549,6 +1549,16 @@ def make_url_map(app):
             json_renderer,
         ),
 
+        Rule(
+            [
+                '/project/<pid>/rmap/',
+                '/project/<pid>/node/<nid>/rmap/',
+            ],
+            'post',
+            project_views.rmap.node_rmap_post,
+            json_renderer,
+        ),
+
         # Statistics
         Rule([
             '/project/<pid>/statistics/',


### PR DESCRIPTION
## Purpose

Add endpoint to generate an RMap for a node.

## Changes

* Add v1 endpoint to generate an RMap

## Side effects

Need to set `RMAP_URL` to `website/settings/local.py`.

## TODO

* [ ] Fill in code to make request to RMap service
* [ ] Make sure that RMaps can be regenerated

