### PR TITLE
[WIP] Working rmap endpoint

### DIFF
--- a/website/project/views/rmap.py
+++ b/website/project/views/rmap.py
@@ -1,14 +1,41 @@
+import requests
+
 from framework.exceptions import HTTPError
 from website.project.decorators import (
     must_be_valid_project,
     must_have_permission,
 )
 from website.util.permissions import ADMIN
+from website import settings
 
+
+def _rmap_url_for_node(node):
+    target = 'osf_registration' if node.is_registration else 'osf_node'
+    return 'http://{rmap_pass}@{base_url}/transforms/{target}/?id={nid}'.format(
+        rmap_pass=settings.RMAP_PASS,
+        base_url=settings.RMAP_BASE_URL.rstrip('/'),
+        target=target,
+        nid=node._id
+    )
+
+def _rmap_url_for_user(user):
+    return 'http://{rmap_pass}@{base_url}/transforms/osf_user/?id={uid}'.format(
+        rmap_pass=settings.RMAP_PASS,
+        base_url=settings.RMAP_BASE_URL.rstrip('/'),
+        uid=user._id
+    )
 
 def _create_rmap_for_node(node):
-    # TODO: Make request to RMAP service
-    return '<rmapid would be returned>'
+    if not settings.RMAP_BASE_URL or not settings.RMAP_PASS:
+        # Need to configure RMAP_URL
+        raise HTTPError(503, data=dict(message_long='RMap service disabled at this time.'))
+    url = _rmap_url_for_node(node)
+    response = requests.post(url)
+    try:
+        response.raise_for_status()
+    except requests.exceptions.HTTPError:
+        raise HTTPError(response.status_code)
+    return response.text  # the DiscoID
 
 
 @must_be_valid_project
@@ -18,8 +45,8 @@ def node_rmap_post(node, auth, *args, **kwargs):
         raise HTTPError(400, data=dict(message_long='RMaps can only be created '
                                        'for public projects. Make your project public '
                                        'and retry your request.'))
-    rmap_id = _create_rmap_for_node(node)
-    node.set_identifier_value('rmap', rmap_id)
+    disco_id = _create_rmap_for_node(node)
+    node.set_identifier_value('disco', disco_id)
     return {
-        'rmap_id': rmap_id
+        'disco_id': disco_id
     }, 201

--- a/website/settings/defaults.py
+++ b/website/settings/defaults.py
@@ -1749,3 +1749,8 @@ SPAM_FLAGGED_REMOVE_FROM_SEARCH = False
 
 SHARE_URL = 'http://localhost:8000/'
 SHARE_API_TOKEN = None
+
+
+# RMaps
+RMAP_BASE_URL = None  # e.g. "rmaptransform:8080/transforms"
+RMAP_PASS = None


### PR DESCRIPTION

## Purpose

Implements a working `/api/v1/project/<pid>/rmap/` endpoint. When POSTed to by an admin OSF user, the server will request to the RMAP service (configured by RMAP_BASE_URL and RMAP_PASS in `website/settings/local.py`. 
